### PR TITLE
Property values might not fit between min and max int32

### DIFF
--- a/geobuf/encode.py
+++ b/geobuf/encode.py
@@ -164,8 +164,11 @@ class Encoder:
 
 
     def encode_int(self, val, value):
-        if val >= 0: value.pos_int_value = val;
-        else: value.neg_int_value = -val;
+        try:
+            if val >= 0: value.pos_int_value = val;
+            else: value.neg_int_value = -val;
+        except ValueError:
+            value.double_value = val
 
 
     def encode_id(self, obj, id):


### PR DESCRIPTION
For example, we were given a geojson with these properties:

`"properties": {"shape_area": 899051524699.0, "objectid": 1}`

Raises a ValueError in line 119 of /google/protobuf/internal/type_checkers.py, with the following comments:

We force 32-bit values to int and 64-bit values to long to make
alternate implementations where the distinction is more significant